### PR TITLE
Add in a standard issue_template for all the repos

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,4 +1,4 @@
-Thank you for wanting to create an issue in this repository, but before you do please ensure you are filing the issue in the right place. Issues should only be opened on if the issues **relates to code in this repository**.
+Thank you 🙇‍♀ for wanting to create an issue in this repository. Before you do please ensure you are filing the issue in the right place. Issues should only be opened on if the issue **relates to code in this repository**.
 
 * If you have found a security issue [please submit it here](https://hackerone.com/github)
 * If you are having an issue or question about GitHub Actions then please [contact customer support](https://help.github.com/en/articles/about-github-actions#contacting-support)

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,7 @@
+Thank you for wanting to create an issue in this repository, but before you do please ensure you are filing the issue in the right place. Issues should only be opened on if the issues **relates to code in this repository**.
+
+* If you have found a security issue [please submit it here](https://hackerone.com/github)
+* If you are having an issue or question about GitHub Actions then please [contact customer support](https://help.github.com/en/articles/about-github-actions#contacting-support)
+* If you have questions about to write workflow or action files then please [visit the community forum](https://github.community/t5/GitHub-Actions/bd-p/actions)
+
+If your issue is relevant to this repository, please go ahead and file it here. Thank you in advance.

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,4 +1,4 @@
-Thank you 🙇‍♀ for wanting to create an issue in this repository. Before you do please ensure you are filing the issue in the right place. Issues should only be opened on if the issue **relates to code in this repository**.
+Thank you 🙇‍♀ for wanting to create an issue in this repository. Before you do, please ensure you are filing the issue in the right place. Issues should only be opened on if the issue **relates to code in this repository**.
 
 * If you have found a security issue [please submit it here](https://hackerone.com/github)
 * If you are having an issue or question about GitHub Actions then please [contact customer support](https://help.github.com/en/articles/about-github-actions#contacting-support)


### PR DESCRIPTION
* Adds in a standard `issue_template` for all repos in this org I've done this using the legacy approach so that a user isn't presented with a choice, but an issue populated with this text straight off.

