### PR TITLE
Fix busted link in issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,7 +1,7 @@
 Thank you 🙇‍♀ for wanting to create an issue in this repository. Before you do, please ensure you are filing the issue in the right place. Issues should only be opened on if the issue **relates to code in this repository**.
 
 * If you have found a security issue [please submit it here](https://hackerone.com/github)
-* If you have questions about writing workflows or action files, then please [visit the GitHub Community Forum's Actions Board](https://github.community/t5/GitHub-Actions/bd-p/actions)
+* If you have questions about writing workflows or action files, then please [visit the GitHub Community Forum's Actions Board](https://github.community/c/code-to-cloud/github-actions)
 * If you are having an issue or question about GitHub Actions then please [contact customer support](https://help.github.com/en/articles/about-github-actions#contacting-support)
 
 If your issue is relevant to this repository, please delete this text and continue to create this issue. Thank you in advance.


### PR DESCRIPTION
If you create a blank issue in any repo in the `actions` org, the issue template has a busted link.

Should now redirect to: https://github.community/c/code-to-cloud/github-actions/41

Resolves: https://github.com/actions/upload-artifact/issues/132